### PR TITLE
pass * as the registration callback

### DIFF
--- a/irctest/controllers/oragono.py
+++ b/irctest/controllers/oragono.py
@@ -132,7 +132,7 @@ class OragonoController(BaseServerController, DirectoryBasedController):
         while case.getRegistrationMessage(client).command != '001':
             pass
         list(case.getMessages(client))
-        case.sendLine(client, 'ACC REGISTER {} passphrase {}'.format(
+        case.sendLine(client, 'ACC REGISTER {} * passphrase {}'.format(
             username, password))
         msg = case.getMessage(client)
         assert msg.command == '920', msg


### PR DESCRIPTION
If I read the [spec](https://github.com/DanielOaks/ircv3-specifications/blob/register-and-verify/extensions/acc-core.md) correctly, a callback argument is required? Anyway, the current oragono trunk tolerates its omission, but my branch doesn't.