### PR TITLE
add a test for MODE +i and RPL_WHOISCHANNELS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# vim swapfiles
+*.swp

--- a/irctest/controllers/oragono.py
+++ b/irctest/controllers/oragono.py
@@ -70,6 +70,11 @@ limits:
     linelen:
         tags: 2048
         rest: 2048
+
+history:
+    enabled: true
+    channel-length: 128
+    client-length: 128
 """
 
 class OragonoController(BaseServerController, DirectoryBasedController):

--- a/irctest/server_tests/test_channel_operations.py
+++ b/irctest/server_tests/test_channel_operations.py
@@ -487,3 +487,35 @@ class testChannelCaseSensitivity(cases.BaseServerTestCase):
     testRfcSimpleNotEquivalent = _testChannelsNotEquivalent('rfc1459', '#Foo', '#fooa')
     testRfcFancyEquivalent = _testChannelsEquivalent('rfc1459', '#F]|oo{', '#f}\\oo[')
     testRfcFancyNotEquivalent = _testChannelsEquivalent('rfc1459', '#F}o\\o[', '#f]o|o{')
+
+
+class InviteTestCase(cases.BaseServerTestCase):
+
+    @cases.SpecificationSelector.requiredBySpecification('IRCv3.2')
+    def testInvites(self):
+        """Test some basic functionality related to INVITE and the +i mode."""
+        self.connectClient('foo')
+        self.joinChannel(1, '#chan')
+        self.sendLine(1, 'MODE #chan +i')
+        self.getMessages(1)
+        self.sendLine(1, 'INVITE bar #chan')
+        m = self.getMessage(1)
+        self.assertEqual(m.command, '401') # ERR_NOSUCHNICK
+
+        self.connectClient('bar')
+        self.sendLine(2, 'JOIN #chan')
+        m = self.getMessage(2)
+        self.assertEqual(m.command, '473') # ERR_INVITEONLYCHAN
+
+        self.sendLine(1, 'INVITE bar #chan')
+        m = self.getMessage(1)
+        self.assertEqual(m.command, '341') # RPL_INVITING
+        # modern/ircv3 param order: inviter, invitee, channel
+        self.assertEqual(m.params, ['foo', 'bar', '#chan'])
+        m = self.getMessage(2)
+        self.assertEqual(m.command, 'INVITE')
+        self.assertTrue(m.prefix.startswith("foo")) # nickmask of inviter
+        self.assertEqual(m.params, ['bar', '#chan'])
+
+        # we were invited, so join should succeed now
+        self.joinChannel(2, '#chan')

--- a/irctest/server_tests/test_user_commands.py
+++ b/irctest/server_tests/test_user_commands.py
@@ -1,0 +1,60 @@
+"""
+User commands as specified in Section 3.6 of RFC 2812:
+<https://tools.ietf.org/html/rfc2812#section-3.6>
+"""
+
+from irctest import cases
+
+RPL_WHOISCHANNELS = '319'
+
+class InvisibleTestCase(cases.BaseServerTestCase):
+
+    @cases.SpecificationSelector.requiredBySpecification('Oragono')
+    def testInvisibleWhois(self):
+        """Test interaction between MODE +i and RPL_WHOISCHANNELS."""
+        self.connectClient('userOne')
+        self.sendLine(1, 'JOIN #xyz')
+
+        self.connectClient('userTwo')
+        self.getMessages(2)
+        self.sendLine(2, 'WHOIS userOne')
+        commands = {m.command for m in self.getMessages(2)}
+        self.assertIn(RPL_WHOISCHANNELS, commands,
+             'RPL_WHOISCHANNELS should be sent for a non-invisible nick')
+
+        self.getMessages(1)
+        self.sendLine(1, 'MODE userOne +i')
+        message = self.getMessage(1)
+        self.assertEqual(message.command, 'MODE',
+            'Expected MODE reply, but received {}'.format(message.command))
+        self.assertEqual(message.params, ['userOne', '+i'],
+            'Expected user set +i, but received {}'.format(message.params))
+
+        self.getMessages(2)
+        self.sendLine(2, 'WHOIS userOne')
+        commands = {m.command for m in self.getMessages(2)}
+        self.assertNotIn(RPL_WHOISCHANNELS, commands,
+            'RPL_WHOISCHANNELS should not be sent for an invisible nick'
+            'unless the user is also a member of the channel')
+
+        self.sendLine(2, 'JOIN #xyz')
+        self.sendLine(2, 'WHOIS userOne')
+        commands = {m.command for m in self.getMessages(2)}
+        self.assertIn(RPL_WHOISCHANNELS, commands,
+             'RPL_WHOISCHANNELS should be sent for an invisible nick'
+             'if the user is also a member of the channel')
+
+        self.sendLine(2, 'PART #xyz')
+        self.getMessages(2)
+        self.getMessages(1)
+        self.sendLine(1, 'MODE userOne -i')
+        message = self.getMessage(1)
+        self.assertEqual(message.command, 'MODE',
+            'Expected MODE reply, but received {}'.format(message.command))
+        self.assertEqual(message.params, ['userOne', '-i'],
+            'Expected user set -i, but received {}'.format(message.params))
+
+        self.sendLine(2, 'WHOIS userOne')
+        commands = {m.command for m in self.getMessages(2)}
+        self.assertIn(RPL_WHOISCHANNELS, commands,
+             'RPL_WHOISCHANNELS should be sent for a non-invisible nick')

--- a/irctest/specifications.py
+++ b/irctest/specifications.py
@@ -8,6 +8,7 @@ class Specifications(enum.Enum):
     IRC301 = 'IRCv3.1'
     IRC302 = 'IRCv3.2'
     IRC302Deprecated = 'IRCv3.2-deprecated'
+    Oragono = 'Oragono'
 
     @classmethod
     def of_name(cls, name):


### PR DESCRIPTION
I added a specification named `Oragono` for oragono behaviors that are not formally specified (even in the modern ircdocs).