### PR TITLE
more tests

### DIFF
--- a/irctest/controllers/oragono.py
+++ b/irctest/controllers/oragono.py
@@ -51,6 +51,7 @@ accounts:
         enabled-callbacks:
             - none # no verification needed, will instantly register successfully
         allow-multiple-per-connection: true
+        bcrypt-cost: 4
 
     authentication-enabled: true
 

--- a/irctest/controllers/oragono.py
+++ b/irctest/controllers/oragono.py
@@ -1,5 +1,4 @@
 import os
-import time
 import subprocess
 
 from irctest.basecontrollers import NotImplementedByController

--- a/irctest/server_tests/test_account_tag.py
+++ b/irctest/server_tests/test_account_tag.py
@@ -3,8 +3,6 @@
 """
 
 from irctest import cases
-from irctest.client_mock import NoMessageException
-from irctest.basecontrollers import NotImplementedByController
 
 class AccountTagTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
     def connectRegisteredClient(self, nick):

--- a/irctest/server_tests/test_cap.py
+++ b/irctest/server_tests/test_cap.py
@@ -95,3 +95,33 @@ class CapTestCase(cases.BaseServerTestCase):
                 subcommand='ACK', subparams=['multi-prefix'],
                 fail_msg='Expected “CAP ACK :multi-prefix” after '
                 'sending “CAP REQ :multi-prefix”, but got {msg}.')
+
+    @cases.SpecificationSelector.requiredBySpecification('Oragono')
+    def testCapRemovalByClient(self):
+        """Test CAP LIST and removal of caps via CAP REQ :-tagname."""
+        self.addClient(1)
+        self.sendLine(1, 'CAP LS 302')
+        self.assertIn('multi-prefix', self.getCapLs(1))
+        self.sendLine(1, 'CAP REQ :echo-message server-time')
+        self.sendLine(1, 'nick bar')
+        self.sendLine(1, 'user user 0 * realname')
+        self.sendLine(1, 'CAP END')
+        self.skipToWelcome(1)
+        self.getMessages(1)
+
+        self.sendLine(1, 'CAP LIST')
+        messages = self.getMessages(1)
+        cap_list = [m for m in messages if m.command == 'CAP'][0]
+        self.assertEqual(set(cap_list.params[2].split()), {'echo-message', 'server-time'})
+        self.assertIn('time', cap_list.tags)
+
+        # remove the server-time cap
+        self.sendLine(1, 'CAP REQ :-server-time')
+        self.getMessages(1)
+
+        # server-time should be disabled
+        self.sendLine(1, 'CAP LIST')
+        messages = self.getMessages(1)
+        cap_list = [m for m in messages if m.command == 'CAP'][0]
+        self.assertEqual(set(cap_list.params[2].split()), {'echo-message'})
+        self.assertNotIn('time', cap_list.tags)

--- a/irctest/server_tests/test_cap.py
+++ b/irctest/server_tests/test_cap.py
@@ -1,5 +1,4 @@
 from irctest import cases
-from irctest.irc_utils.message_parser import Message
 
 class CapTestCase(cases.BaseServerTestCase):
     @cases.SpecificationSelector.requiredBySpecification('IRCv3.1')

--- a/irctest/server_tests/test_channel_operations.py
+++ b/irctest/server_tests/test_channel_operations.py
@@ -333,8 +333,6 @@ class JoinTestCase(cases.BaseServerTestCase):
 
         # TODO: check foo is an operator
 
-        import time
-        time.sleep(0.1)
         self.getMessages(1)
         self.getMessages(2)
         self.getMessages(3)

--- a/irctest/server_tests/test_channel_operations.py
+++ b/irctest/server_tests/test_channel_operations.py
@@ -9,6 +9,11 @@ from irctest import runner
 from irctest.irc_utils import ambiguities
 
 RPL_NOTOPIC = '331'
+RPL_NAMREPLY = '353'
+
+ERR_NOSUCHCHANNEL = '403'
+ERR_NOTONCHANNEL = '442'
+ERR_CHANOPRIVSNEEDED = '482'
 
 class JoinTestCase(cases.BaseServerTestCase):
     @cases.SpecificationSelector.requiredBySpecification('RFC1459', 'RFC2812',
@@ -352,6 +357,52 @@ class JoinTestCase(cases.BaseServerTestCase):
         m = self.getMessage(3)
         self.assertMessageEqual(m, command='KICK',
                 params=['#chan', 'bar', 'bye'])
+
+    @cases.SpecificationSelector.requiredBySpecification('RFC2812')
+    def testKickPrivileges(self):
+        """Test who has the ability to kick / what error codes are sent for invalid kicks."""
+        self.connectClient('foo')
+        self.sendLine(1, 'JOIN #chan')
+        self.getMessages(1)
+
+        self.connectClient('bar')
+        self.sendLine(2, 'JOIN #chan')
+
+        messages = self.getMessages(2)
+        names = set()
+        for message in messages:
+            if message.command == RPL_NAMREPLY:
+                names.update(set(message.params[-1].split()))
+        # assert foo is opped
+        self.assertIn('@foo', names, f'unexpected names: {names}')
+
+        self.connectClient('baz')
+
+        self.sendLine(3, 'KICK #chan bar')
+        replies = set(m.command for m in self.getMessages(3))
+        self.assertTrue(
+            ERR_NOTONCHANNEL in replies or ERR_CHANOPRIVSNEEDED in replies or ERR_NOSUCHCHANNEL in replies,
+            f'did not receive acceptable error code for kick from outside channel: {replies}')
+
+        self.joinChannel(3, '#chan')
+        self.getMessages(3)
+        self.sendLine(3, 'KICK #chan bar')
+        replies = set(m.command for m in self.getMessages(3))
+        # now we're a channel member so we should receive ERR_CHANOPRIVSNEEDED
+        self.assertIn(ERR_CHANOPRIVSNEEDED, replies)
+
+        self.sendLine(1, 'MODE #chan +o baz')
+        self.getMessages(1)
+        # should be able to kick an unprivileged user:
+        self.sendLine(3, 'KICK #chan bar')
+        # should be able to kick an operator:
+        self.sendLine(3, 'KICK #chan foo')
+        baz_replies = set(m.command for m in self.getMessages(3))
+        self.assertNotIn(ERR_CHANOPRIVSNEEDED, baz_replies)
+        kick_targets = [m.params[1] for m in self.getMessages(1) if m.command == 'KICK']
+        # foo should see bar and foo being kicked
+        self.assertTrue(any(target.startswith('foo') for target in kick_targets), f'unexpected kick targets: {kick_targets}')
+        self.assertTrue(any(target.startswith('bar') for target in kick_targets), f'unexpected kick targets: {kick_targets}')
 
     @cases.SpecificationSelector.requiredBySpecification('RFC2812')
     def testKickNonexistentChannel(self):

--- a/irctest/server_tests/test_connection_registration.py
+++ b/irctest/server_tests/test_connection_registration.py
@@ -4,9 +4,6 @@ Tests section 4.1 of RFC 1459.
 """
 
 from irctest import cases
-from irctest import authentication
-from irctest.irc_utils.message_parser import Message
-from irctest.basecontrollers import NotImplementedByController
 from irctest.client_mock import ConnectionClosed
 
 class PasswordedConnectionRegistrationTestCase(cases.BaseServerTestCase):

--- a/irctest/server_tests/test_connection_registration.py
+++ b/irctest/server_tests/test_connection_registration.py
@@ -32,6 +32,16 @@ class PasswordedConnectionRegistrationTestCase(cases.BaseServerTestCase):
                 msg='Got 001 after NICK+USER but missing PASS')
 
     @cases.SpecificationSelector.requiredBySpecification('RFC1459', 'RFC2812')
+    def testWrongPassword(self):
+        self.addClient()
+        self.sendLine(1, 'PASS {}'.format(self.password + "garbage"))
+        self.sendLine(1, 'NICK foo')
+        self.sendLine(1, 'USER username * * :Realname')
+        m = self.getRegistrationMessage(1)
+        self.assertNotEqual(m.command, '001',
+                msg='Got 001 after NICK+USER but incorrect PASS')
+
+    @cases.SpecificationSelector.requiredBySpecification('RFC1459', 'RFC2812')
     def testPassAfterNickuser(self):
         """“The password can and must be set before any attempt to register
         the connection is made.”

--- a/irctest/server_tests/test_echo_message.py
+++ b/irctest/server_tests/test_echo_message.py
@@ -22,7 +22,7 @@ class EchoMessageTestCase(cases.BaseServerTestCase):
             # TODO: check also without this
             self.sendLine(1, 'CAP REQ :echo-message{}'.format(
                 ' server-time' if server_time else ''))
-            m = self.getRegistrationMessage(1)
+            self.getRegistrationMessage(1)
             # TODO: Remove this one the trailing space issue is fixed in Charybdis
             # and Mammon:
             #self.assertMessageEqual(m, command='CAP',

--- a/irctest/server_tests/test_extended_join.py
+++ b/irctest/server_tests/test_extended_join.py
@@ -3,7 +3,6 @@
 """
 
 from irctest import cases
-from irctest.irc_utils.message_parser import Message
 
 class MetadataTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
     def connectRegisteredClient(self, nick):
@@ -41,7 +40,7 @@ class MetadataTestCase(cases.BaseServerTestCase, cases.OptionalityHelper):
 
     @cases.SpecificationSelector.requiredBySpecification('IRCv3.1')
     @cases.OptionalityHelper.skipUnlessHasMechanism('PLAIN')
-    def testNotLoggedIn(self):
+    def testLoggedIn(self):
         self.connectClient('foo', capabilities=['extended-join'],
                 skip_if_cap_nak=True)
         self.joinChannel(1, '#chan')

--- a/irctest/server_tests/test_messages.py
+++ b/irctest/server_tests/test_messages.py
@@ -4,10 +4,6 @@ Section 3.2 of RFC 2812
 """
 
 from irctest import cases
-from irctest import client_mock
-from irctest import runner
-from irctest.irc_utils import ambiguities
-from irctest.irc_utils.message_parser import Message
 
 class PrivmsgTestCase(cases.BaseServerTestCase):
     @cases.SpecificationSelector.requiredBySpecification('RFC1459', 'RFC2812')

--- a/irctest/server_tests/test_metadata.py
+++ b/irctest/server_tests/test_metadata.py
@@ -4,7 +4,6 @@ Tests METADATA features.
 """
 
 from irctest import cases
-from irctest.irc_utils.message_parser import Message
 
 class MetadataTestCase(cases.BaseServerTestCase):
     valid_metadata_keys = {'valid_key1', 'valid_key2'}

--- a/irctest/server_tests/test_monitor.py
+++ b/irctest/server_tests/test_monitor.py
@@ -88,7 +88,7 @@ class EchoMessageTestCase(cases.BaseServerTestCase):
         self.assertMonoffline(1, 'bar')
 
     @cases.SpecificationSelector.requiredBySpecification('IRCv3.2')
-    def testMonitorOneConnection(self):
+    def testMonitorOneConnectionWithQuit(self):
         self.connectClient('foo')
         self.check_server_support()
         self.connectClient('bar')

--- a/irctest/server_tests/test_multi_prefix.py
+++ b/irctest/server_tests/test_multi_prefix.py
@@ -4,10 +4,6 @@ Tests multi-prefix.
 """
 
 from irctest import cases
-from irctest import client_mock
-from irctest import runner
-from irctest.irc_utils import ambiguities
-from irctest.irc_utils.message_parser import Message
 
 class MultiPrefixTestCase(cases.BaseServerTestCase):
     @cases.SpecificationSelector.requiredBySpecification('IRCv3.1')

--- a/irctest/server_tests/test_sasl.py
+++ b/irctest/server_tests/test_sasl.py
@@ -1,7 +1,6 @@
 import base64
 
 from irctest import cases
-from irctest.irc_utils.message_parser import Message
 
 class RegistrationTestCase(cases.BaseServerTestCase):
     def testRegistration(self):

--- a/irctest/server_tests/test_user_commands.py
+++ b/irctest/server_tests/test_user_commands.py
@@ -5,7 +5,35 @@ User commands as specified in Section 3.6 of RFC 2812:
 
 from irctest import cases
 
+RPL_WHOISUSER = '311'
 RPL_WHOISCHANNELS = '319'
+
+class WhoisTestCase(cases.BaseServerTestCase):
+
+    @cases.SpecificationSelector.requiredBySpecification('RFC2812')
+    def testWhoisUser(self):
+        """Test basic WHOIS behavior"""
+        nick = 'myCoolNickname'
+        username = 'myCoolUsername'
+        realname = 'My Real Name'
+        self.addClient()
+        self.sendLine(1, f'NICK {nick}')
+        self.sendLine(1, f'USER {username} 0 * :{realname}')
+        self.skipToWelcome(1)
+
+        self.connectClient('otherNickname')
+        self.getMessages(2)
+        self.sendLine(2, 'WHOIS mycoolnickname')
+        messages = self.getMessages(2)
+        whois_user = messages[0]
+        self.assertEqual(whois_user.command, RPL_WHOISUSER)
+        #  "<client> <nick> <username> <host> * :<realname>"
+        self.assertEqual(whois_user.params[1], nick)
+        self.assertEqual(whois_user.params[2], '~' + username)
+        # dumb regression test for oragono/oragono#355:
+        self.assertNotIn(whois_user.params[3], [nick, username, '~' + username, realname])
+        self.assertEqual(whois_user.params[5], realname)
+
 
 class InvisibleTestCase(cases.BaseServerTestCase):
 


### PR DESCRIPTION
Closes #15, #16, #18, #19.

Plus, I pyflaked all the server tests, and two tests were being shadowed because they were reusing names. So we get two more tests for free --- fortunately, they pass!