### PR TITLE
misc fixes

### DIFF
--- a/irctest/cases.py
+++ b/irctest/cases.py
@@ -267,6 +267,8 @@ class BaseServerTestCase(_IrcTestCase):
         self.clients[name] = client_mock.ClientMock(name=name,
                 show_io=show_io)
         self.clients[name].connect(self.hostname, self.port)
+        if self.ssl:
+            self.clients[name].starttls()
         return name
 
 

--- a/irctest/client_mock.py
+++ b/irctest/client_mock.py
@@ -97,7 +97,7 @@ class ClientMock:
         except BrokenPipeError:
             raise ConnectionClosed()
         if self.ssl: # https://bugs.python.org/issue25951
-            assert ret == len(encoded_line), (ret, repr(encoded_line))
+            assert ret is None or ret == len(encoded_line), (ret, repr(encoded_line))
         else:
             assert ret is None, ret
         if self.show_io:

--- a/irctest/server_tests/test_regressions.py
+++ b/irctest/server_tests/test_regressions.py
@@ -52,7 +52,7 @@ class RegressionsTestCase(cases.BaseServerTestCase):
     @cases.SpecificationSelector.requiredBySpecification('IRCv3.2')
     def testTagCap(self):
         # regression test for oragono #754
-        self.connectClient('alice', capabilities=['message-tags', 'batch', 'echo-message', 'server-time'])
+        self.connectClient('alice', capabilities=['message-tags', 'batch', 'echo-message', 'server-time'], skip_if_cap_nak=True)
         self.connectClient('bob')
         self.getMessages(1)
         self.getMessages(2)

--- a/irctest/server_tests/test_user_commands.py
+++ b/irctest/server_tests/test_user_commands.py
@@ -27,7 +27,7 @@ class WhoisTestCase(cases.BaseServerTestCase):
         self.assertEqual(whois_user.command, RPL_WHOISUSER)
         #  "<client> <nick> <username> <host> * :<realname>"
         self.assertEqual(whois_user.params[1], nick)
-        self.assertEqual(whois_user.params[2], '~' + username)
+        self.assertIn(whois_user.params[2], ['~' + username, username])
         # dumb regression test for oragono/oragono#355:
         self.assertNotIn(whois_user.params[3], [nick, username, '~' + username, realname])
         self.assertEqual(whois_user.params[5], realname)


### PR DESCRIPTION
some fixes i had to add to make irctest work for my ircd.

running the tests on non-oragono servers is broken right now, even with these fixes, because some test cases with oragono tests still call setUp, tearDown that end up calling oragono-specific functions on the controllers, like baseConfig and addMysqlToConfig.

as a hotfix i added to my controller:
```
    def baseConfig(self):
        return {}

    def addMysqlToConfig(self, config=None):
        pass
```

also changed the run function to:
```
 def run(self, hostname, port, password=None, ssl=False,
            restricted_metadata_keys=None,
            valid_metadata_keys=None, invalid_metadata_keys=None, config=None):
```
because the tests need the config parameter even though it's oragono specific stuff.

so yeah the project is kinda broken for non-oragono servers anyways but here's some fixes for issues i had.